### PR TITLE
Remove filter for event reason, only filter by whether service name is empty or not

### DIFF
--- a/assets/default-config.yaml
+++ b/assets/default-config.yaml
@@ -17,7 +17,7 @@
 #
 
 filters:
-  - reason: "Started|Killing"     # filter events of the specified reason, regular expression like "Killing|Killed" is supported.
+  - reason: ""     # filter events of the specified reason, regular expression like "Killing|Killed" is supported.
     message: ""    # filter events of the specified message, regular expression like "Pulling container.*" is supported.
     minCount: 1    # filter events whose count is >= the specified value.
     type: ""       # filter events of the specified type, regular expression like "Normal|Error" is supported.

--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -25,7 +25,7 @@ filters:
     kind: ""       # filter events of the specified kind, regular expression like "Pod|Service" is supported.
     namespace: "default"  # filter events from the specified namespace, regular expression like "default|bookinfo" is supported, empty means all namespaces.
     name: ""       # filter events of the specified involved object name, regular expression like ".*bookinfo.*" is supported.
-    service: ""  # filter events belonging to services whose name is not empty.
+    service: "[^\\s]{1,}"  # filter events belonging to services whose name is not empty.
     exporters:     # events satisfy this filter can be exported into several exporters that are defined in the `exporters` section below.
       - console
 

--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -22,7 +22,7 @@ filters:
     minCount: 1    # filter events whose count is >= the specified value.
     type: ""       # filter events of the specified type, regular expression like "Normal|Error" is supported.
     action: ""     # filter events of the specified action, regular expression is supported.
-    kind: ""       # filter events of the specified kind, regular expression like "Pod|Service" is supported.
+    kind: "Pod|Service"       # filter events of the specified kind, regular expression like "Pod|Service" is supported.
     namespace: "default"  # filter events from the specified namespace, regular expression like "default|bookinfo" is supported, empty means all namespaces.
     name: ""       # filter events of the specified involved object name, regular expression like ".*bookinfo.*" is supported.
     service: "[^\\s]{1,}"  # filter events belonging to services whose name is not empty.

--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -17,15 +17,15 @@
 #
 
 filters:
-  - reason: "Started|Killing"     # filter events of the specified reason, regular expression like "Killing|Killed" is supported.
+  - reason: ""     # filter events of the specified reason, regular expression like "Killing|Killed" is supported.
     message: ""    # filter events of the specified message, regular expression like "Pulling container.*" is supported.
     minCount: 1    # filter events whose count is >= the specified value.
     type: ""       # filter events of the specified type, regular expression like "Normal|Error" is supported.
     action: ""     # filter events of the specified action, regular expression is supported.
-    kind: "Pod|Service"       # filter events of the specified kind, regular expression like "Pod|Service" is supported.
+    kind: ""       # filter events of the specified kind, regular expression like "Pod|Service" is supported.
     namespace: "default"  # filter events from the specified namespace, regular expression like "default|bookinfo" is supported, empty means all namespaces.
     name: ""       # filter events of the specified involved object name, regular expression like ".*bookinfo.*" is supported.
-    service: "[^\\s]{1,}"  # filter events belonging to services whose name is not empty.
+    service: ""  # filter events belonging to services whose name is not empty.
     exporters:     # events satisfy this filter can be exported into several exporters that are defined in the `exporters` section below.
       - console
 


### PR DESCRIPTION
As exporter is able to identify the event's service, we can simply let go of all events and only filter by whether or not the service name is empty.